### PR TITLE
meta.yaml: Allow building for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+os: osx
+osx_image: xcode6.4
+
+env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
+  global:
+    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
+    - secure: "HeCiwcfnckJPK2iKD+5LbHX9wQNfqYC3uICXQBPKfiVO7PCFsbFw3LnGDgbECW0bqFI99OdS+i2F3REhNsD+84pGPeF7EBaU/qISy7FRwDkivQtCPgDTy/eFmM3xrACJ59Ifzqk4LdqzDItnH9vTZS9i9kIAbwcYasH9M84BN/mpdM1joW2+ndvpqasQjNbyyI1ZOS6L3bHFhlU2fNBBbXoOaoSa7boMNvVM8Gi5auI7+SjhLbAZg4OpBriYFfB3ikNNiAjVa0Zw3GFW5JEzaiJiKwzKI5xKnzXs9x1EOxtrEDuINBYjNCgY/Tiwo4XNAsU/RVglSww/XcNn3X3J59NVIe+inXAH6Xbpozv8pLPSyJbLbqQaN188aimu/1dD6GQ4U+hkTjApulk7yzkDYcHsCYySo2pe13YIMZ4UIAbzL2wIMwu6AADgy82tFwQPTBFFM5vYqBBrxc1TNV2W3jw2Uc5PlpDVYMIOnDOq7pQ6Zw2nxno12efqbPUjbcKuTloDHkL37kpqhCYTO8aki+x/DuGtpOMD00DfXMbqHPc/ZJXyHKhwhamuqBghp+WP8yoeJ1/h3Pd+6Hftm4fZCJO8v63We97lDJd04SrzTZ03eirVFKPKlBsMwPtdOngBmlIYI4rdcFaXDkhXpToBPxVWndOSvRalmqvG8dDOvCI="
+
+
+before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
+    # Remove homebrew.
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
+
+install:
+    # Install Miniconda.
+    - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
+      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      bash $MINICONDA_FILE -b
+
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
+      source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
+      conda config --add channels conda-forge
+      conda config --set show_channel_urls true
+      conda install --yes --quiet conda-forge-build-setup
+      source run_conda_forge_build_setup
+
+script:
+  - conda build ./recipe
+
+  - upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/hdfs3-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/hdfs3-feedstock)
-OSX: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/hdfs3-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/hdfs3-feedstock)
 Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
 
 Current release info
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
   # This packages uses libhdfs3, which is primarily used with HDFS on Linux.
-  skip: True  # [not linux]
+  skip: True  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Fixes conda-forge/hdfs3-feedstock#10

Note: This needs the PR https://github.com/conda-forge/libhdfs3-feedstock/pull/16 to be merged from the downstream dependency on `libhdfs3`